### PR TITLE
Improved memory performance.

### DIFF
--- a/NaCl.net/Internal/Common.cs
+++ b/NaCl.net/Internal/Common.cs
@@ -6,7 +6,7 @@ namespace NaCl.Internal
     internal static class Common
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static UInt32 Load32(ReadOnlySpan<byte> src, int offset)
+        public static UInt32 Load32(byte[] src, int offset)
         {
             UInt32 w = (UInt32) src[offset];
             w |= (UInt32) src[offset + 1] << 8;
@@ -14,6 +14,26 @@ namespace NaCl.Internal
             w |= (UInt32) src[offset + 3] << 24;
             return w;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static UInt32 Load32(ReadOnlySpan<byte> src, int offset)
+        {
+            UInt32 w = (UInt32)src[offset];
+            w |= (UInt32)src[offset + 1] << 8;
+            w |= (UInt32)src[offset + 2] << 16;
+            w |= (UInt32)src[offset + 3] << 24;
+            return w;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Store(byte[] dst, int offset, UInt32 w)
+        {
+            dst[offset] = (byte)w; w >>= 8;
+            dst[offset + 1] = (byte)w; w >>= 8;
+            dst[offset + 2] = (byte)w; w >>= 8;
+            dst[offset + 3] = (byte)w;
+        }
+
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Store(Span<byte> dst, int offset, UInt32 w)

--- a/NaCl.net/Internal/Salsa20.cs
+++ b/NaCl.net/Internal/Salsa20.cs
@@ -9,6 +9,123 @@ namespace NaCl.Internal
         public const int KeyLength = 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Transform(byte[] output, byte[] input, byte[] k,
+            byte[] c)
+        {
+            UInt32 x0;
+            UInt32 x1;
+            UInt32 x2;
+            UInt32 x3;
+            UInt32 x4;
+            UInt32 x5;
+            UInt32 x6;
+            UInt32 x7;
+            UInt32 x8;
+            UInt32 x9;
+            UInt32 x10;
+            UInt32 x11;
+            UInt32 x12;
+            UInt32 x13;
+            UInt32 x14;
+            UInt32 x15;
+            UInt32 j0;
+            UInt32 j1;
+            UInt32 j2;
+            UInt32 j3;
+            UInt32 j4;
+            UInt32 j5;
+            UInt32 j6;
+            UInt32 j7;
+            UInt32 j8;
+            UInt32 j9;
+            UInt32 j10;
+            UInt32 j11;
+            UInt32 j12;
+            UInt32 j13;
+            UInt32 j14;
+            UInt32 j15;
+
+            j0 = x0 = 0x61707865;
+            j5 = x5 = 0x3320646e;
+            j10 = x10 = 0x79622d32;
+            j15 = x15 = 0x6b206574;
+            if (c!= null)
+            {
+                j0 = x0 = Common.Load32(c, 0);
+                j5 = x5 = Common.Load32(c, 4);
+                j10 = x10 = Common.Load32(c, 8);
+                j15 = x15 = Common.Load32(c, 12);
+            }
+
+            j1 = x1 = Common.Load32(k, 0);
+            j2 = x2 = Common.Load32(k, 4);
+            j3 = x3 = Common.Load32(k, 8);
+            j4 = x4 = Common.Load32(k, 12);
+            j11 = x11 = Common.Load32(k, 16);
+            j12 = x12 = Common.Load32(k, 20);
+            j13 = x13 = Common.Load32(k, 24);
+            j14 = x14 = Common.Load32(k, 28);
+
+            j6 = x6 = Common.Load32(input, 0);
+            j7 = x7 = Common.Load32(input, 4);
+            j8 = x8 = Common.Load32(input, 8);
+            j9 = x9 = Common.Load32(input, 12);
+
+            for (int i = 0; i < Rounds; i += 2)
+            {
+                x4 ^= Common.RotateLeft(x0 + x12, 7);
+                x8 ^= Common.RotateLeft(x4 + x0, 9);
+                x12 ^= Common.RotateLeft(x8 + x4, 13);
+                x0 ^= Common.RotateLeft(x12 + x8, 18);
+                x9 ^= Common.RotateLeft(x5 + x1, 7);
+                x13 ^= Common.RotateLeft(x9 + x5, 9);
+                x1 ^= Common.RotateLeft(x13 + x9, 13);
+                x5 ^= Common.RotateLeft(x1 + x13, 18);
+                x14 ^= Common.RotateLeft(x10 + x6, 7);
+                x2 ^= Common.RotateLeft(x14 + x10, 9);
+                x6 ^= Common.RotateLeft(x2 + x14, 13);
+                x10 ^= Common.RotateLeft(x6 + x2, 18);
+                x3 ^= Common.RotateLeft(x15 + x11, 7);
+                x7 ^= Common.RotateLeft(x3 + x15, 9);
+                x11 ^= Common.RotateLeft(x7 + x3, 13);
+                x15 ^= Common.RotateLeft(x11 + x7, 18);
+                x1 ^= Common.RotateLeft(x0 + x3, 7);
+                x2 ^= Common.RotateLeft(x1 + x0, 9);
+                x3 ^= Common.RotateLeft(x2 + x1, 13);
+                x0 ^= Common.RotateLeft(x3 + x2, 18);
+                x6 ^= Common.RotateLeft(x5 + x4, 7);
+                x7 ^= Common.RotateLeft(x6 + x5, 9);
+                x4 ^= Common.RotateLeft(x7 + x6, 13);
+                x5 ^= Common.RotateLeft(x4 + x7, 18);
+                x11 ^= Common.RotateLeft(x10 + x9, 7);
+                x8 ^= Common.RotateLeft(x11 + x10, 9);
+                x9 ^= Common.RotateLeft(x8 + x11, 13);
+                x10 ^= Common.RotateLeft(x9 + x8, 18);
+                x12 ^= Common.RotateLeft(x15 + x14, 7);
+                x13 ^= Common.RotateLeft(x12 + x15, 9);
+                x14 ^= Common.RotateLeft(x13 + x12, 13);
+                x15 ^= Common.RotateLeft(x14 + x13, 18);
+            }
+
+            Common.Store(output, 0, x0 + j0);
+            Common.Store(output, 4, x1 + j1);
+            Common.Store(output, 8, x2 + j2);
+            Common.Store(output, 12, x3 + j3);
+            Common.Store(output, 16, x4 + j4);
+            Common.Store(output, 20, x5 + j5);
+            Common.Store(output, 24, x6 + j6);
+            Common.Store(output, 28, x7 + j7);
+            Common.Store(output, 32, x8 + j8);
+            Common.Store(output, 36, x9 + j9);
+            Common.Store(output, 40, x10 + j10);
+            Common.Store(output, 44, x11 + j11);
+            Common.Store(output, 48, x12 + j12);
+            Common.Store(output, 52, x13 + j13);
+            Common.Store(output, 56, x14 + j14);
+            Common.Store(output, 60, x15 + j15);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Transform(Span<byte> output, ReadOnlySpan<byte> input, ReadOnlySpan<byte> k,
             ReadOnlySpan<byte> c)
         {

--- a/NaCl.net/Internal/StreamSalsa20.cs
+++ b/NaCl.net/Internal/StreamSalsa20.cs
@@ -11,25 +11,24 @@ namespace NaCl.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static public void Transform(Span<byte> c, ReadOnlySpan<byte> n, ReadOnlySpan<byte> k)
         {
-            Span<byte> input = new byte[16];
-            Span<byte> block = new byte[64];
-            Span<byte> kcopy = new byte[32];
-
             if (c.IsEmpty)
                 return;
 
-            for (int i = 0; i < 32; i++)
-                kcopy[i] = k[i];
-            
+            var input = new byte[16];
+            var block = new byte[64];
+            var kcopy = k.ToArray();
+
             for (int i = 0; i < 8; i++)
                 input[i] = n[i];
             
-            for (int i = 8; i < 16; i++)
-                input[i] = 0;
-            
             while (c.Length >= 64)
             {
-                Salsa20.Transform(c, input, kcopy, Span<byte>.Empty);
+                Salsa20.Transform(block, input, kcopy, null);
+
+                for (int i = 0; i < c.Length; i++)
+                    c[i] = block[i];
+
+
                 uint u = 1;
                 for (int i = 8; i < 16; i++)
                 {
@@ -43,13 +42,10 @@ namespace NaCl.Internal
 
             if (c.Length != 0)
             {
-                Salsa20.Transform(block, input, kcopy, Span<byte>.Empty);
+                Salsa20.Transform(block, input, kcopy, null);
                 for (int i = 0; i < c.Length; i++)
                     c[i] = block[i];
             }
-
-            block.Clear();
-            kcopy.Clear();
         }
     }
 }

--- a/NaCl.net/Internal/StreamSalsa20Xor.cs
+++ b/NaCl.net/Internal/StreamSalsa20Xor.cs
@@ -9,23 +9,15 @@ namespace NaCl.Internal
         public static void Transform(Span<byte> c, ReadOnlySpan<byte> m, ReadOnlySpan<byte> n, ReadOnlySpan<byte> k,
             UInt64 ic = 0)
         {
-            Span<byte> input = stackalloc byte[16];
-            Span<byte> block = stackalloc byte[64];
-            Span<byte> kcopy = stackalloc byte[32];
-            UInt32 u;
-
             if (m.Length == 0)
                 return;
 
-            for (int i = 0; i < 32; i++)
-            {
-                kcopy[i] = k[i];
-            }
+            var input = new  byte[16];
+            var block = new  byte[64];
+            var kcopy = k.Slice(0, 32).ToArray();
+            UInt32 u;
 
-            for (int i = 0; i < 8; i++)
-            {
-                input[i] = n[i];
-            }
+            n.Slice(0, 8).CopyTo(input);
 
             for (int i = 8; i < 16; i++)
             {
@@ -37,10 +29,11 @@ namespace NaCl.Internal
 
             while (mlen >= 64)
             {
-                Salsa20.Transform(block, input, kcopy, ReadOnlySpan<byte>.Empty);
+                Salsa20.Transform(block, input, kcopy, null);
+
                 for (int i = 0; i < 64; i++)
                 {
-                    c[i] = (byte) (m[i] ^ block[i]);
+                    c[i] = (byte)(m[i] ^ block[i]);
                 }
 
                 u = 1;
@@ -58,15 +51,13 @@ namespace NaCl.Internal
 
             if (mlen != 0)
             {
-                Salsa20.Transform(block, input, kcopy, ReadOnlySpan<byte>.Empty);
+                Salsa20.Transform(block, input, kcopy, null);
                 for (int i = 0; i < mlen; i++)
                 {
                     c[i] = (byte) (m[i] ^ block[i]);
                 }
             }
-
-            block.Clear();
-            kcopy.Clear();
         }
+
     }
 }


### PR DESCRIPTION
Compared to NaCl.net version 0.1.12, I am now able to send 1000000 bytes of data in ~85% of the time compared to previous version. So roughly ~18.5% performance increase.