### PR TITLE
Add package license info

### DIFF
--- a/NaCl.net/NaCl.net.csproj
+++ b/NaCl.net/NaCl.net.csproj
@@ -25,6 +25,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>NaCl libsodium sodium curve25519 xsalsa poly1305</PackageTags>
     <DelaySign>true</DelaySign>
+    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The NuGet package does not include license information, which causes static analysis tools that look at the metadata to declare it as an unlicensed dependency.