### PR TITLE
Remove unused dependencies from net472 build

### DIFF
--- a/NaCl.net/NaCl.net.csproj
+++ b/NaCl.net/NaCl.net.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 
     <LangVersion>8</LangVersion>
@@ -39,8 +39,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR removes unused dependencies from the net472 target framework build. The net472 and netstandard2.0 targets are basically equivalent, as .NET 4.7 introduced tuple support for framework projects.